### PR TITLE
fix(OS): support for windows

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -6,12 +6,12 @@ Note that the binaries are available in `./node_modules/.bin`.
 
 In watch and development mode:
 
-```
-webpack -dw
+```sh
+npm start
 ```
 
 ## Start the HTTP server
 
-```
-http-server dist
+```sh
+npm run server
 ```

--- a/example/package.json
+++ b/example/package.json
@@ -1,8 +1,12 @@
 {
+  "scripts": {
+    "start": "webpack -dw",
+    "server": "ws -d dist"
+  },
   "devDependencies": {
     "@wasm-tool/rust-loader": "0.0.1",
     "html-webpack-plugin": "^3.2.0",
-    "http-server": "^0.1.2",
+    "local-web-server": "^2.6.0",
     "webpack": "^4.16.3",
     "webpack-cli": "^3.1.0"
   }

--- a/loader.js
+++ b/loader.js
@@ -1,6 +1,4 @@
-const { execSync } = require('child_process');
 const { spawn } = require('child_process');
-const { readFileSync } = require('fs');
 const { join, dirname } = require('path');
 
 function spawnWasmPack({ isDebug, cwd }) {
@@ -62,11 +60,10 @@ module.exports = function() {
   })
     .then(() => {
       const pkg = require(join(pkgDir, "./package.json"));
-
+      const exportPath = join(pkgDir, pkg.main).replace(/\\/g, '/');
       const wrapper = `
-        export * from "${pkgDir}/${pkg.main}";
+        export * from "${exportPath}";
       `;
-
       callback(null, wrapper);
     })
     .catch(callback);


### PR DESCRIPTION
I've unified the path so it can work well also in Windows.

On the other hand, `http-server` wasn't working because some issues with Windows and MIME types so I've changed the dependency to one working in all operating systems (`local-web-server`).

Finally, I've updated the example's README.